### PR TITLE
Documentation ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ jobs:
       install:
         - pip install -r molecule/requirements.txt
       script:
-        - molecule test
+        - cd docs
+        - make html
     - stage: build-docker
       script:
         - >2

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -32,6 +32,15 @@ End to End
 
 Continuous integration
 ----------------------
+The continuous interation process is composed of two parts which are Azure
+Pipelines and Travis-CI.
+
+Azure pipeline handles the molecule testing of the role by providing a virtual
+machine per molecule senario. Azure pipelines are managed via the
+``azure-pipelines.yml`` file.
+
+Travis-CI handles all the other builds like documentation, docker images,
+releases, ... Travis-CI is configured via the ``.travis-ci.yml`` file.
 
 Molecule
 --------

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -3,3 +3,4 @@ docker-py==1.10.6
 IMAPClient==2.1.0
 psycopg2-binary
 dnspython
+Sphinx


### PR DESCRIPTION
### Description
Builds the documentation during the CI.
Removes duplicate tests from travis-ci.
Adds a small documentation about the CI process.

Fixes #57 

### Checklist
- [x] Molecule tests are passing
- [x] Extended the README / documentation, if necessary
- [x] Test for the feature added

