### PR TITLE
Add vanilla rspamd without redis

### DIFF
--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -13,6 +13,7 @@
   hosts: mta
   roles:
     - ispmail-certificate
+    - ispmail-rspamd
     - ispmail-postfix
   tags:
     - postfix

--- a/roles/ispmail-postfix/defaults/main.yml
+++ b/roles/ispmail-postfix/defaults/main.yml
@@ -7,3 +7,4 @@ ispmail_postfix_database_hosts:
   - unix:/var/run/postgresql
 ispmail_postfix_database_password: "{{ lookup('password',
   'credentials/postfix_database_password length=15') }}"
+ispmail_postfix_smtpd_milters: "inet:localhost:11332"

--- a/roles/ispmail-postfix/templates/main.cf.j2
+++ b/roles/ispmail-postfix/templates/main.cf.j2
@@ -213,7 +213,7 @@ milter_default_action = tempfail
 # We use Postfix > 2.6, so we can use milter_protocol 6
 milter_protocol = 6
 # We take all the mails and filter them, SMTP or not.
-#smtpd_milters = unix:/var/run/opendkim/opendkim.sock
+smtpd_milters = {{ ispmail_postfix_smtpd_milters }}
 #non_smtpd_milters = unix:/var/run/opendkim/opendkim.sock
 # unix:/run/spamass.sock
 #milter_connect_macros = j {daemon_name} v {if_name} _

--- a/roles/ispmail-rspamd/tasks/main.yml
+++ b/roles/ispmail-rspamd/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Add rspamd APT signing key
+  apt_key:
+    url: https://rspamd.com/apt-stable/gpg.key
+    state: present
+  register: apt_key_result
+  retries: 3
+  until: apt_key_result is succeeded
+
+- name: Add Rspamd APT repository
+  apt_repository:
+    repo: >-2
+      {{ item }} [arch=amd64]
+      http://rspamd.com/apt-stable/
+      {{ ansible_distribution_release }} main
+    state: present
+    filename: rspamd
+    update_cache: true
+  loop:
+    - deb
+    - deb-src
+
+- name: Install rspamd packages
+  apt:
+    name: rspamd
+    state: present
+  register: apt_result
+  until: apt_result is succeeded
+  retries: 3


### PR DESCRIPTION
### Description
Install basic rspamd and integrate with postfix. No custom configuration yet.

Fixes #71, fixes #72

### Checklist
- [x] Molecule tests are passing
- [ ] Extended the README / documentation, if necessary
- [x] Test for the feature added

