### PR TITLE
Nginx for letsencrypt

### DIFF
--- a/host_vars/test-double/north.yml
+++ b/host_vars/test-double/north.yml
@@ -1,2 +1,3 @@
 ---
 ispmail_dovecot_replication_peer: south.mail.local
+domain_name: north.mail.local

--- a/host_vars/test-double/south.yml
+++ b/host_vars/test-double/south.yml
@@ -1,2 +1,3 @@
 ---
 ispmail_dovecot_replication_peer: north.mail.local
+domain_name: south.mail.local

--- a/host_vars/test-single/single.yml
+++ b/host_vars/test-single/single.yml
@@ -1,0 +1,2 @@
+---
+domain_name: "single.mail.local"

--- a/host_vars/test-single/single.yml
+++ b/host_vars/test-single/single.yml
@@ -1,2 +1,2 @@
 ---
-domain_name: "single.mail.local"
+domain_name: single.mail.local

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ platforms:
       - mta
       - mda
       - db
-      - rp
+      - reverse_proxy
       - test
     image: minimum2scp/systemd-stretch
     privileged: true
@@ -25,7 +25,7 @@ platforms:
 
   - name: south
     groups:
-      - rp
+      - reverse_proxy
       - mta
       - mda
       - test

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,6 +15,7 @@ platforms:
       - mta
       - mda
       - db
+      - rp
       - test
     image: minimum2scp/systemd-stretch
     privileged: true
@@ -24,6 +25,7 @@ platforms:
 
   - name: south
     groups:
+      - rp
       - mta
       - mda
       - test

--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -1,4 +1,13 @@
 ---
+- name: Deploy reverse proxy
+  hosts: reverse_proxy
+  # reverse_proxy = mta + mda + antispam
+  roles:
+    - ispmail-nginx
+  tags:
+    - reverse_proxy
+    - nginx
+
 - name: Deploy database
   hosts: db
   roles:

--- a/molecule/single/molecule.yml
+++ b/molecule/single/molecule.yml
@@ -13,7 +13,7 @@ platforms:
   - name: single
     groups:
       - mta
-      - rp
+      - reverse_proxy
       - mda
       - db
       - test

--- a/molecule/single/molecule.yml
+++ b/molecule/single/molecule.yml
@@ -13,6 +13,7 @@ platforms:
   - name: single
     groups:
       - mta
+      - rp
       - mda
       - db
       - test
@@ -36,6 +37,7 @@ provisioner:
   inventory:
     links:
       group_vars: ../../group_vars/single
+      host_vars: ../../host_vars/test-single
   playbooks:
     create: ../create.yml
     converge: ../playbook.yml

--- a/roles/ispmail-nginx/handlers/main.yml
+++ b/roles/ispmail-nginx/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded
+  become: true

--- a/roles/ispmail-nginx/tasks/main.yml
+++ b/roles/ispmail-nginx/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Install nginx package
+  apt:
+    name: nginx
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  register: apt_result
+  until: apt_result is succeeded
+  retries: 3
+  become: true
+
+- name: Deploy nginx default template for LE challenge
+  template:
+    src: default.conf.j2
+    dest: /etc/nginx/conf.d/default.conf
+  become: true
+  notify: reload nginx

--- a/roles/ispmail-nginx/templates/default.conf.j2
+++ b/roles/ispmail-nginx/templates/default.conf.j2
@@ -1,0 +1,40 @@
+{# Construct the reverse proxy list : ["server1", "server2"] #}
+{% set reverse_proxies = groups['reverse_proxy'] | difference([ansible_hostname]) %}
+{# Construct the locations list : ["@server1", "@server2"] #}
+{% set reverse_proxy_locations = reverse_proxies | map("regex_replace", "^(.*)$", "@\1") %}
+
+server {
+    listen       80;
+    server_name  {{ domain_name }} default;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    # Avoids infinite loop if the challenge is not on the server
+    location /noloop {
+        alias   /var/www/html;
+    }
+
+    location / {
+        root   /var/www/html;
+        index  index.html index.htm;
+        {% if reverse_proxies | length > 0 -%}
+        # If the challenge is not on the server we try forwarding it
+        try_files $uri {{ reverse_proxy_locations|join(' ') }};
+        {% endif -%}
+    }
+
+{% for reverse_proxy in reverse_proxies %}
+    {%- set reverse_proxy_vars = hostvars[reverse_proxy] %}
+    location @{{ reverse_proxy }} {
+        rewrite /(.*) /noloop/$1  break;
+        proxy_pass         http://{{ reverse_proxy_vars["domain_name"] }};
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+    }
+{% endfor %}
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /var/wwww/html;
+    }
+
+}


### PR DESCRIPTION
### Description
Add nginx reverse proxy in order to pass the LE challenge even if the same A entry point to two servers.

### Checklist
- [x] Molecule tests are passing
- [ ] Extended the README / documentation, if necessary
- [ ] Test for the feature added

