### PR TITLE
Pki

### DIFF
--- a/docs/certs.rst
+++ b/docs/certs.rst
@@ -9,7 +9,7 @@ Certificates
 Introduction
 ------------
 
-A lot of differets certificates are used in this role. We can divide them in
+A lot of different certificates are used in this role. We can divide them in
 two categories : 
 
 - certificates that will be used by external entities (MXs, MUA, ...)
@@ -21,7 +21,7 @@ Public facing certs
 -------------------
 
 Those certs should be trusted by the client (MX or MUA).
-For testing setups we're using self-signed certificates, for productions ones
+For testing setups we're using self-signed certificates, for production ones
 letsencrypt is used.
 
 Depending on what protocol is used to contact the server the client will ask
@@ -54,7 +54,7 @@ Internal PKI
 ------------
 
 In case of internal communication we don't need our certs to be trusted by the
-usual PKIs (Public Key Infrastructures). We only need the cert to be trsuted by
+usual PKIs (Public Key Infrastructures). We only need the cert to be trusted by
 all of our servers.
 
 Each server will generate a CA (Certifiate Authority) and sign its certificates

--- a/docs/certs.rst
+++ b/docs/certs.rst
@@ -6,14 +6,68 @@ Certificates
 .. include:: ../roles/ispmail-certificate/defaults/main.yml
    :literal:
 
-Public cert
------------
+Introduction
+------------
 
-Self-signed
-^^^^^^^^^^^
+A lot of differets certificates are used in this role. We can divide them in
+two categories : 
 
-Letsencrypt
-^^^^^^^^^^^
+- certificates that will be used by external entities (MXs, MUA, ...)
+- certificates that are restricted for internal use (DB connection,
+  replication, ...)
+
+
+Public facing certs
+-------------------
+
+Those certs should be trusted by the client (MX or MUA).
+For testing setups we're using self-signed certificates, for productions ones
+letsencrypt is used.
+
+Depending on what protocol is used to contact the server the client will ask
+for a server-specific domain-name or a domain-name shared by both serverA and
+serverB.
+
+Example (FQDN stands for Fully Qualified Domain Name):
+
+serverA::
+  FQDN : serverA.example.com
+
+ServerB::
+  FQDN : serverB.example.com
+
+MX entries::
+  MX 50 mail.example.com serverA.example.com
+  MX 50 mail.example.com serverB.example.com
+
+Submission DNS entry::
+  A submission.example.com <serverA IP>
+  A submission.example.com <serverB IP>
+
+Here an MTA will pick an MX entry and access serverA by its FQDN. So serverA
+should provide a cert valid for ``serverA.example.com``.
+A MUA asking to sumbit new mail through submission will not know there are two
+servers and will ask serverA or serverB for ``submission.example.com``. The
+same goes for IMAP/POP/Sieve.
 
 Internal PKI
 ------------
+
+In case of internal communication we don't need our certs to be trusted by the
+usual PKIs (Public Key Infrastructures). We only need the cert to be trsuted by
+all of our servers.
+
+Each server will generate a CA (Certifiate Authority) and sign its certificates
+with its own CA.
+
+Each server will trust the other servers' CA, thus will trust the other servers
+certificates.
+
+This is our own internal PKI.
+
+Such certs are used for:
+- MDA replication
+
+Those certs will also be used for:
+- LMTP in case of distant MDA
+- DB connection

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,7 @@ platforms:
   # for testing purposes in the create.yml
   - name: north
     groups:
+      - mail
       - mta
       - mda
       - db
@@ -25,6 +26,7 @@ platforms:
 
   - name: south
     groups:
+      - mail
       - reverse_proxy
       - mta
       - mda

--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -8,6 +8,13 @@
     - reverse_proxy
     - nginx
 
+- name: Deploy certificates
+  hosts: mail
+  roles:
+    - ispmail-certificate
+  tags:
+    - certs
+
 - name: Deploy database
   hosts: db
   roles:
@@ -21,7 +28,6 @@
 - name: Deploy mail transfer agent
   hosts: mta
   roles:
-    - ispmail-certificate
     - ispmail-rspamd
     - ispmail-postfix
   tags:
@@ -31,7 +37,6 @@
 - name: Deploy mail delivery agent
   hosts: mda
   roles:
-    - ispmail-certificate
     - ispmail-dovecot
   vars:
     ispmail_debug: true

--- a/molecule/single/molecule.yml
+++ b/molecule/single/molecule.yml
@@ -12,6 +12,7 @@ platforms:
   # for testing purposes in the create.yml
   - name: single
     groups:
+      - mail
       - mta
       - reverse_proxy
       - mda

--- a/roles/ispmail-certificate/defaults/main.yml
+++ b/roles/ispmail-certificate/defaults/main.yml
@@ -14,3 +14,6 @@ ispmail_certificate_domains:
   - example.org
 ispmail_certificate_email: postmaster@example.org
 ispmail_certificate_days_valid: 3650
+
+node_ca_key: /etc/ssl/ca/privkey.pem
+node_ca_cert: /etc/ssl/ca/cert.pem

--- a/roles/ispmail-certificate/handlers/main.yml
+++ b/roles/ispmail-certificate/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: update ca-certificates
+  command: /usr/sbin/update-ca-certificates
+  delegate_to: "{{ item }}"
+  with_inventory_hostnames:
+    - mail
+  become: true

--- a/roles/ispmail-certificate/tasks/main.yml
+++ b/roles/ispmail-certificate/tasks/main.yml
@@ -56,3 +56,6 @@
     provider: selfsigned
     selfsigned_digest: sha512
     state: present
+
+- name: Import PKI tasks
+  import_tasks: pki.yml

--- a/roles/ispmail-certificate/tasks/main.yml
+++ b/roles/ispmail-certificate/tasks/main.yml
@@ -59,3 +59,4 @@
 
 - name: Import PKI tasks
   import_tasks: pki.yml
+  become: true

--- a/roles/ispmail-certificate/tasks/pki.yml
+++ b/roles/ispmail-certificate/tasks/pki.yml
@@ -9,34 +9,29 @@
   loop:
     - "{{ node_ca_key | dirname }}"
     - "{{ node_ca_cert | dirname }}"
-  become: true
 
 - name: Generate an OpenSSL private key.
   openssl_privatekey:
     path: "{{ node_ca_key }}"
-  become: true
 
 - name: Generate an OpenSSL CSR.
   openssl_csr:
     path: "{{ node_ca_key }}.csr"
     privatekey_path: "{{ node_ca_key }}"
     common_name: "{{ domain_name }}"
-  become: true
 
 - name: Generate a Self Signed OpenSSL certificate
+  # cert is valid for 10 years
   openssl_certificate:
     path: "{{ node_ca_cert }}"
     privatekey_path: "{{ node_ca_key }}"
     csr_path: "{{ node_ca_key }}.csr"
     provider: selfsigned
-  become: true
-  # cert is valid for 10 years
 
 - name: Recover certificate
   slurp:
     src: "{{ node_ca_cert }}"
   register: certificate
-  become: true
 
 - name: Trust CA on every server
   copy:
@@ -47,5 +42,4 @@
   delegate_to: "{{ item }}"
   with_inventory_hostnames:
     - mail
-  become: true
   notify: update ca-certificates

--- a/roles/ispmail-certificate/tasks/pki.yml
+++ b/roles/ispmail-certificate/tasks/pki.yml
@@ -1,0 +1,51 @@
+---
+- name: Create TLS directories
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: root
+    group: root
+    mode: 0770
+  loop:
+    - "{{ node_ca_key | dirname }}"
+    - "{{ node_ca_cert | dirname }}"
+  become: true
+
+- name: Generate an OpenSSL private key.
+  openssl_privatekey:
+    path: "{{ node_ca_key }}"
+  become: true
+
+- name: Generate an OpenSSL CSR.
+  openssl_csr:
+    path: "{{ node_ca_key }}.csr"
+    privatekey_path: "{{ node_ca_key }}"
+    common_name: "{{ domain_name }}"
+  become: true
+
+- name: Generate a Self Signed OpenSSL certificate
+  openssl_certificate:
+    path: "{{ node_ca_cert }}"
+    privatekey_path: "{{ node_ca_key }}"
+    csr_path: "{{ node_ca_key }}.csr"
+    provider: selfsigned
+  become: true
+  # cert is valid for 10 years
+
+- name: Recover certificate
+  slurp:
+    src: "{{ node_ca_cert }}"
+  register: certificate
+  become: true
+
+- name: Trust CA on every server
+  copy:
+    content: "{{ certificate['content'] | b64decode }}"
+    dest: "/usr/local/share/ca-certificates/{{ domain_name }}.crt"
+    owner: root
+    group: root
+  delegate_to: "{{ item }}"
+  with_inventory_hostnames:
+    - mail
+  become: true
+  notify: update ca-certificates

--- a/roles/ispmail-dovecot/defaults/main.yml
+++ b/roles/ispmail-dovecot/defaults/main.yml
@@ -11,3 +11,6 @@ ispmail_debug: false
 ispmail_dovecot_doveadm_port: 12345
 ispmail_dovecot_doveadm_secret: "{{ lookup('password',
   'credentials/dovecot_doveadm_password length=15') }}"
+
+certificate_location: /etc/letsencrypt/live/sub.domain.tld/fullchain.pem
+certificate_keyfile: /etc/letsencrypt/live/sub.domain.tld/privkey.pem

--- a/roles/ispmail-dovecot/tasks/main.yml
+++ b/roles/ispmail-dovecot/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Grant user dovecot read permission on the private key
   acl:
-    path: "{{ ispmail_certificate_keyfile }}"
+    path: "{{ certificate_keyfile }}"
     entity: dovecot
     etype: user
     permissions: r

--- a/roles/ispmail-dovecot/templates/10-ssl.conf.j2
+++ b/roles/ispmail-dovecot/templates/10-ssl.conf.j2
@@ -9,8 +9,8 @@ ssl = required
 # dropping root privileges, so keep the key file unreadable by anyone but
 # root. Included doc/mkcert.sh can be used to easily generate self-signed
 # certificate, just make sure to update the domains in dovecot-openssl.cnf
-ssl_cert = <{{ispmail_certificate_location}}
-ssl_key = <{{ispmail_certificate_keyfile}}
+ssl_cert = <{{certificate_location}}
+ssl_key = <{{certificate_keyfile}}
 
 # If key file is password protected, give the password here. Alternatively
 # give it when starting dovecot with -p parameter. Since this file is often
@@ -21,8 +21,8 @@ ssl_key = <{{ispmail_certificate_keyfile}}
 # PEM encoded trusted certificate authority. Set this only if you intend to use
 # ssl_verify_client_cert=yes. The file should contain the CA certificate(s)
 # followed by the matching CRL(s). (e.g. ssl_ca = </etc/ssl/certs/ca.pem)
-{% if ispmail_certificate_cafile is defined %}
-ssl_ca = <{{ispmail_certificate_cafile}}
+{% if certificate_cafile is defined %}
+ssl_ca = <{{certificate_cafile}}
 {% endif %}
 # Require that CRL check succeeds for client certificates.
 #ssl_require_crl = yes

--- a/roles/ispmail-postfix/defaults/main.yml
+++ b/roles/ispmail-postfix/defaults/main.yml
@@ -8,3 +8,6 @@ ispmail_postfix_database_hosts:
 ispmail_postfix_database_password: "{{ lookup('password',
   'credentials/postfix_database_password length=15') }}"
 ispmail_postfix_smtpd_milters: "inet:localhost:11332"
+
+certificate_location: /etc/letsencrypt/live/sub.domain.tld/fullchain.pem
+certificate_keyfile: /etc/letsencrypt/live/sub.domain.tld/privkey.pem

--- a/roles/ispmail-postfix/tasks/main.yml
+++ b/roles/ispmail-postfix/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Grant user postfix read permission on the private key
   acl:
-    path: "{{ ispmail_certificate_keyfile }}"
+    path: "{{ certificate_keyfile }}"
     entity: postfix
     etype: user
     permissions: r

--- a/roles/ispmail-postfix/templates/main.cf.j2
+++ b/roles/ispmail-postfix/templates/main.cf.j2
@@ -115,9 +115,9 @@ readme_directory = no
 ############# TLS parameters ##############
 # We will use TLS connections to secure the email
 # We specify the certificate (signed by a trusted CA)
-smtpd_tls_cert_file = {{ispmail_certificate_location}}
+smtpd_tls_cert_file = {{certificate_location}}
 # We give postfix the private key
-smtpd_tls_key_file = {{ispmail_certificate_keyfile}}
+smtpd_tls_key_file = {{certificate_keyfile}}
 # What random source postfix use
 tls_random_source = dev:/dev/urandom
 


### PR DESCRIPTION
### Description
Deploying a PKI : each node got a CA and trusts the others.
The PKI will later be used in order to sign:
- internal certificates
- self-signed tests certificates

The external certificates will be handled later by letsencrypt. 

Part of #90 

### Checklist
- [x] Molecule tests are passing
- [x] Extended the README / documentation, if necessary
- [ ] Test for the feature added

