### PR TITLE
Pki sign internal certificates

### DIFF
--- a/group_vars/double/db.yml
+++ b/group_vars/double/db.yml
@@ -4,7 +4,8 @@ database_internal_certificate:
   privatekey: /etc/ssl/database/internal/privkey.pem
   csr: /etc/ssl/database/internal/csr.pem
   cert: /etc/ssl/database/internal/cert.pem
-  common_name: "{{ domain_name }}"
+  fullchain: /etc/ssl/database/internal/fullchain.pem
+  common_name: "database.internal.{{ domain_name }}"
   alt_names:
     - "IP:{{ ansible_default_ipv4.address }}"
     - "DNS:{{ domain_name }}"

--- a/group_vars/double/db.yml
+++ b/group_vars/double/db.yml
@@ -1,0 +1,12 @@
+---
+database_internal_certificate:
+  name: database internal
+  privatekey: /etc/ssl/database/internal/privkey.pem
+  csr: /etc/ssl/database/internal/csr.pem
+  cert: /etc/ssl/database/internal/cert.pem
+  common_name: "{{ domain_name }}"
+  alt_names:
+    - "IP:{{ ansible_default_ipv4.address }}"
+    - "DNS:{{ domain_name }}"
+
+ispmail_database_internal_certs: "{{ [database_internal_certificate] }}"

--- a/group_vars/double/mda.yml
+++ b/group_vars/double/mda.yml
@@ -4,7 +4,8 @@ dovecot_internal_certificate:
   privatekey: /etc/ssl/dovecot/internal/privkey.pem
   csr: /etc/ssl/dovecot/internal/csr.pem
   cert: /etc/ssl/dovecot/internal/cert.pem
-  common_name: "{{ domain_name }}"
+  fullchain: /etc/ssl/dovecot/internal/fullchain.pem
+  common_name: "dovecot.internal.{{ domain_name }}"
   alt_names:
     - "IP:{{ ansible_default_ipv4.address }}"
     - "DNS:{{ domain_name }}"

--- a/group_vars/double/mda.yml
+++ b/group_vars/double/mda.yml
@@ -1,0 +1,12 @@
+---
+dovecot_internal_certificate:
+  name: dovecot internal
+  privatekey: /etc/ssl/dovecot/internal/privkey.pem
+  csr: /etc/ssl/dovecot/internal/csr.pem
+  cert: /etc/ssl/dovecot/internal/cert.pem
+  common_name: "{{ domain_name }}"
+  alt_names:
+    - "IP:{{ ansible_default_ipv4.address }}"
+    - "DNS:{{ domain_name }}"
+
+ispmail_dovecot_internal_certs: "{{ [dovecot_internal_certificate] }}"

--- a/group_vars/double/mta.yml
+++ b/group_vars/double/mta.yml
@@ -4,7 +4,8 @@ postfix_internal_certificate:
   privatekey: /etc/ssl/postfix/internal/privkey.pem
   csr: /etc/ssl/postfix/internal/csr.pem
   cert: /etc/ssl/postfix/internal/cert.pem
-  common_name: "{{ domain_name }}"
+  fullchain: /etc/ssl/postfix/internal/fullchain.pem
+  common_name: "postfix.internal.{{ domain_name }}"
   alt_names:
     - "IP:{{ ansible_default_ipv4.address }}"
     - "DNS:{{ domain_name }}"

--- a/group_vars/double/mta.yml
+++ b/group_vars/double/mta.yml
@@ -1,0 +1,12 @@
+---
+postfix_internal_certificate:
+  name: postfix internal
+  privatekey: /etc/ssl/postfix/internal/privkey.pem
+  csr: /etc/ssl/postfix/internal/csr.pem
+  cert: /etc/ssl/postfix/internal/cert.pem
+  common_name: "{{ domain_name }}"
+  alt_names:
+    - "IP:{{ ansible_default_ipv4.address }}"
+    - "DNS:{{ domain_name }}"
+
+ispmail_postfix_internal_certs: "{{ [postfix_internal_certificate] }}"

--- a/molecule/playbook.yml
+++ b/molecule/playbook.yml
@@ -9,7 +9,7 @@
     - nginx
 
 - name: Deploy certificates
-  hosts: mail
+  hosts: mail:mta:mda:reverse_proxy:db
   roles:
     - ispmail-certificate
   tags:

--- a/roles/ispmail-certificate/defaults/main.yml
+++ b/roles/ispmail-certificate/defaults/main.yml
@@ -17,3 +17,19 @@ ispmail_certificate_days_valid: 3650
 
 node_ca_key: /etc/ssl/ca/privkey.pem
 node_ca_cert: /etc/ssl/ca/cert.pem
+
+# Internal certs items should follow the same structure as in this example.
+# internal_certs:
+#  - name: dovecot internal
+#    privatekey: /etc/ssl/dovecot/internal/privkey.pem
+#    csr: /etc/ssl/dovecot/internal/csr.pem
+#    cert: /etc/ssl/dovecot/internal/cert.pem
+#    common_name: "{{ domain_name }}"
+#    alt_names:
+#      - "IP:{{ ansible_default_ipv4.address }}"
+#      - "DNS:{{ domain_name }}"
+
+ispmail_internal_certs: "{{
+    ispmail_postfix_internal_certs|default([]) +
+    ispmail_dovecot_internal_certs|default([]) +
+    ispmail_database_internal_certs|default([]) }}"

--- a/roles/ispmail-certificate/defaults/main.yml
+++ b/roles/ispmail-certificate/defaults/main.yml
@@ -24,6 +24,7 @@ node_ca_cert: /etc/ssl/ca/cert.pem
 #    privatekey: /etc/ssl/dovecot/internal/privkey.pem
 #    csr: /etc/ssl/dovecot/internal/csr.pem
 #    cert: /etc/ssl/dovecot/internal/cert.pem
+#    fullchain: /etc/ssl/dovecot/internal/fullchain.pem
 #    common_name: "{{ domain_name }}"
 #    alt_names:
 #      - "IP:{{ ansible_default_ipv4.address }}"

--- a/roles/ispmail-certificate/tasks/internal-certs.yml
+++ b/roles/ispmail-certificate/tasks/internal-certs.yml
@@ -31,7 +31,7 @@
   loop: "{{ ispmail_internal_certs }}"
   become: true
 
-- name: Generate a Self Signed OpenSSL certificate
+- name: Sign internal certificate
   openssl_certificate:
     path: "{{ item.cert }}"
     ownca_path: "{{ node_ca_cert }}"
@@ -42,3 +42,19 @@
     state: present
   loop: "{{ ispmail_internal_certs }}"
   become: true
+
+- name: Read certificate content
+  slurp:
+    src: "{{ item.cert }}"
+  register: internal_certs
+  loop: "{{ ispmail_internal_certs }}"
+
+- name: Write fullchain
+  copy:
+    content: |-
+      {{ item.content | b64decode }}
+      {{ ca_certificate.content | b64decode }}
+    dest: "{{ item.item.fullchain }}"
+    owner: root
+    group: root
+  loop: "{{ internal_certs.results }}"

--- a/roles/ispmail-certificate/tasks/internal-certs.yml
+++ b/roles/ispmail-certificate/tasks/internal-certs.yml
@@ -1,39 +1,13 @@
 ---
-- name: Generate the list of certificates to be created
-  set_fact:
-    # TODO(shaka) : add conditional here
-    # TODO(shaka) : sign demo certs if demo mode
-    ispmail_internal_tls_material:
-      - name: dovecot internal
-        privatekey: /etc/ssl/dovecot/internal/privkey.pem
-        csr: /etc/ssl/dovecot/internal/csr.pem
-        cert: /etc/ssl/dovecot/internal/cert.pem
-        common_name: "{{ domain_name }}"
-        alt_names:
-          - "IP:{{ ansible_default_ipv4.address }}"
-          - "DNS:{{ domain_name }}"
-      - name: postfix internal
-        privatekey: /etc/ssl/postfix/internal/privkey.pem
-        csr: /etc/ssl/postfix/internal/csr.pem
-        cert: /etc/ssl/postfix/internal/cert.pem
-        common_name: "{{ domain_name }}"
-        alt_names:
-          - "IP:{{ ansible_default_ipv4.address }}"
-          - "DNS:{{ domain_name }}"
-      - name: database internal
-        privatekey: /etc/ssl/postgres/internal/privkey.pem
-        csr: /etc/ssl/postgres/internal/csr.pem
-        cert: /etc/ssl/postgres/internal/cert.pem
-        common_name: "{{ domain_name }}"
-        alt_names:
-          - "IP:{{ ansible_default_ipv4.address }}"
-          - "DNS:{{ domain_name }}"
-
 - name: Create directories
   file:
     path: "{{ item[0][item[1]]| dirname }}"
     state: directory
-  loop: "{{ ispmail_internal_tls_material | product(['privatekey', 'csr', 'cert']) | list}}"
+  loop: "{{
+    ispmail_internal_certs
+    | product(['privatekey', 'csr', 'cert'])
+    | list
+  }}"
   become: true
 
 - name: Generate OpenSSL private keys
@@ -43,7 +17,7 @@
     mode: 0640
     group: root
     owner: root
-  loop: "{{ ispmail_internal_tls_material }}"
+  loop: "{{ ispmail_internal_certs }}"
   become: true
 
 - name: Generate an OpenSSL Certificate Signing Request
@@ -54,7 +28,7 @@
     subject_alt_name: "{{ item.alt_names }}"
     digest: sha512
     state: present
-  loop: "{{ ispmail_internal_tls_material }}"
+  loop: "{{ ispmail_internal_certs }}"
   become: true
 
 - name: Generate a Self Signed OpenSSL certificate
@@ -66,5 +40,5 @@
     valid_in: "{{ 60*60*24*365 }}"
     provider: ownca
     state: present
-  loop: "{{ ispmail_internal_tls_material }}"
+  loop: "{{ ispmail_internal_certs }}"
   become: true

--- a/roles/ispmail-certificate/tasks/internal-certs.yml
+++ b/roles/ispmail-certificate/tasks/internal-certs.yml
@@ -1,0 +1,70 @@
+---
+- name: Generate the list of certificates to be created
+  set_fact:
+    # TODO(shaka) : add conditional here
+    # TODO(shaka) : sign demo certs if demo mode
+    ispmail_internal_tls_material:
+      - name: dovecot internal
+        privatekey: /etc/ssl/dovecot/internal/privkey.pem
+        csr: /etc/ssl/dovecot/internal/csr.pem
+        cert: /etc/ssl/dovecot/internal/cert.pem
+        common_name: "{{ domain_name }}"
+        alt_names:
+          - "IP:{{ ansible_default_ipv4.address }}"
+          - "DNS:{{ domain_name }}"
+      - name: postfix internal
+        privatekey: /etc/ssl/postfix/internal/privkey.pem
+        csr: /etc/ssl/postfix/internal/csr.pem
+        cert: /etc/ssl/postfix/internal/cert.pem
+        common_name: "{{ domain_name }}"
+        alt_names:
+          - "IP:{{ ansible_default_ipv4.address }}"
+          - "DNS:{{ domain_name }}"
+      - name: database internal
+        privatekey: /etc/ssl/postgres/internal/privkey.pem
+        csr: /etc/ssl/postgres/internal/csr.pem
+        cert: /etc/ssl/postgres/internal/cert.pem
+        common_name: "{{ domain_name }}"
+        alt_names:
+          - "IP:{{ ansible_default_ipv4.address }}"
+          - "DNS:{{ domain_name }}"
+
+- name: Create directories
+  file:
+    path: "{{ item[0][item[1]]| dirname }}"
+    state: directory
+  loop: "{{ ispmail_internal_tls_material | product(['privatekey', 'csr', 'cert']) | list}}"
+  become: true
+
+- name: Generate OpenSSL private keys
+  openssl_privatekey:
+    path: "{{ item.privatekey }}"
+    state: present
+    mode: 0640
+    group: root
+    owner: root
+  loop: "{{ ispmail_internal_tls_material }}"
+  become: true
+
+- name: Generate an OpenSSL Certificate Signing Request
+  openssl_csr:
+    path: "{{ item.csr }}"
+    privatekey_path: "{{ item.privatekey }}"
+    common_name: "{{ item.common_name }}"
+    subject_alt_name: "{{ item.alt_names }}"
+    digest: sha512
+    state: present
+  loop: "{{ ispmail_internal_tls_material }}"
+  become: true
+
+- name: Generate a Self Signed OpenSSL certificate
+  openssl_certificate:
+    path: "{{ item.cert }}"
+    ownca_path: "{{ node_ca_cert }}"
+    ownca_privatekey_path: "{{ node_ca_key }}"
+    csr_path: "{{ item.csr }}"
+    valid_in: "{{ 60*60*24*365 }}"
+    provider: ownca
+    state: present
+  loop: "{{ ispmail_internal_tls_material }}"
+  become: true

--- a/roles/ispmail-certificate/tasks/main.yml
+++ b/roles/ispmail-certificate/tasks/main.yml
@@ -60,3 +60,6 @@
 - name: Import PKI tasks
   import_tasks: pki.yml
   become: true
+
+- name: Import internal certs tasks
+  import_tasks: internal-certs.yml

--- a/roles/ispmail-certificate/tasks/pki.yml
+++ b/roles/ispmail-certificate/tasks/pki.yml
@@ -19,6 +19,7 @@
     path: "{{ node_ca_key }}.csr"
     privatekey_path: "{{ node_ca_key }}"
     common_name: "{{ domain_name }}"
+    basic_constraints: "CA:true"
 
 - name: Generate a Self Signed OpenSSL certificate
   # cert is valid for 10 years

--- a/roles/ispmail-certificate/tasks/pki.yml
+++ b/roles/ispmail-certificate/tasks/pki.yml
@@ -31,11 +31,11 @@
 - name: Recover certificate
   slurp:
     src: "{{ node_ca_cert }}"
-  register: certificate
+  register: ca_certificate
 
 - name: Trust CA on every server
   copy:
-    content: "{{ certificate['content'] | b64decode }}"
+    content: "{{ ca_certificate['content'] | b64decode }}"
     dest: "/usr/local/share/ca-certificates/{{ domain_name }}.crt"
     owner: root
     group: root


### PR DESCRIPTION
### Description
Generates internal certificates for dovecot, postfix and postgres trusted by the PKI.

Part of #90 

### Checklist
- [x] Molecule tests are passing
- [ ] Extended the README / documentation, if necessary
- [ ] Test for the feature added