### PR TITLE
Bump ansible, molecule, testinfra, fix test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 log
 .tags
 .tags*
-.venv
+.venv*
 *.retry
 *junit-report.xml
 __pycache__

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -67,7 +67,7 @@ verifier:
     - ../../test/suite/additional/replication.py
   options:
     junit-xml: junit-report.xml
-    host: north,south
+    hosts: north,south
     verbosity: 2
   lint:
     name: flake8

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,4 @@
-molecule==2.19.0
+molecule==2.22
 docker-py==1.10.6
 IMAPClient==2.1.0
 psycopg2-binary

--- a/molecule/single/molecule.yml
+++ b/molecule/single/molecule.yml
@@ -52,7 +52,7 @@ verifier:
   directory: ../../test/suite/
   options:
     junit-xml: junit-report.xml
-    host: single
+    hosts: single
     verbosity: 2
   lint:
     name: flake8

--- a/molecule/yamllint.yml
+++ b/molecule/yamllint.yml
@@ -11,4 +11,7 @@ rules:
   line-length:  # 80 chars should be enough, but don't fail if a line is longer
     max: 80
     level: warning
+
+ignore: |
+  .venv*/
 ...

--- a/roles/ispmail-certificate/tasks/pki.yml
+++ b/roles/ispmail-certificate/tasks/pki.yml
@@ -19,7 +19,7 @@
     path: "{{ node_ca_key }}.csr"
     privatekey_path: "{{ node_ca_key }}"
     common_name: "{{ domain_name }}"
-    basic_constraints: "CA:true"
+    basic_constraints: "CA:TRUE"
 
 - name: Generate a Self Signed OpenSSL certificate
   # cert is valid for 10 years

--- a/roles/ispmail-database/handlers/initialize.yml
+++ b/roles/ispmail-database/handlers/initialize.yml
@@ -3,6 +3,7 @@
   copy:
     src: schema.sql
     dest: /tmp
+  listen: initialize database
 
 - name: Set up SQL schema of mailserver database
   postgresql_db:
@@ -11,6 +12,7 @@
     target: /tmp/schema.sql
   become: true
   become_user: postgres
+  listen: initialize database
 
 - name: Give pgadmin rights on the mail db
   postgresql_privs:
@@ -26,6 +28,7 @@
     - virtual_users
   become: true
   become_user: postgres
+  listen: initialize database
 
   # This line is mandatory in order for pgadmin to be able to use the SERIALs
 - name: Give pgadmin rights on the mail db serials
@@ -42,6 +45,7 @@
     - virtual_users_id_seq
   become: true
   become_user: postgres
+  listen: initialize database
 
 - name: Give mail user rights on the mail db
   postgresql_privs:
@@ -57,3 +61,4 @@
     - virtual_users
   become: true
   become_user: postgres
+  listen: initialize database

--- a/roles/ispmail-database/handlers/main.yml
+++ b/roles/ispmail-database/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: initialize database
-  include: initialize.yml
+  import_tasks: initialize.yml
 
 - name: restart postgresql
   service:

--- a/test/suite/additional/replication.py
+++ b/test/suite/additional/replication.py
@@ -19,7 +19,7 @@ def servers():
 
     server_ips = []
     for mda_host in mda_hosts:
-        mda_facts = inventory.run(mda_host, "setup")
+        mda_facts = inventory.run_module(mda_host, "setup", [])
         mda_ip = mda_facts["ansible_facts"]["ansible_default_ipv4"]["address"]
         server_ips.append(mda_ip)
 

--- a/test/suite/test_imap.py
+++ b/test/suite/test_imap.py
@@ -8,7 +8,7 @@ from tools import server_address, database_address  # noqa: F401
 
 
 @pytest.fixture(scope="module")  # noqa: F811
-def server(server_address, database_address):
+def server(server_address, database_address):  # noqa: F811
     """Add fixtures into the database before teesting"""
 
     domains = [(1, "sith.local"), (2, "jedi.local")]

--- a/test/suite/test_smtp.py
+++ b/test/suite/test_smtp.py
@@ -9,7 +9,7 @@ from tools import server_address, database_address  # noqa: F401
 
 
 @pytest.fixture(scope="module")  # noqa: F811
-def server(server_address, database_address):
+def server(server_address, database_address):  # noqa: F811
     """Add fixtures into the database before testing"""
 
     domains = [(1, "sith.local"), (2, "jedi.local")]

--- a/test/suite/tools.py
+++ b/test/suite/tools.py
@@ -70,7 +70,7 @@ def database_address(request):
     database_hosts = inventory.get_hosts("db")
     if len(database_hosts) != 1:
         raise ValueError("Multiple databases are not correctly suported")
-    database_facts = inventory.run(database_hosts[0], "setup")
+    database_facts = inventory.run_module(database_hosts[0], "setup", [])
     database_ip = database_facts["ansible_facts"]["ansible_default_ipv4"]["address"]
 
     return database_ip


### PR DESCRIPTION
### Description
Bumps molecule to 2.22, ansible to 2.8.5, and fixes all the broken tests.

### Checklist
- [x] Molecule tests are passing
- [ ] Extended the README / documentation, if necessary
- [ ] Test for the feature added

