### PR TITLE
Add a meta file for ansible-galaxy role install

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,32 @@
+---
+galaxy_info:
+  author: Hugo Shaka
+  description: Setup an entire mailserver stack
+  license: GPLv3
+  min_ansible_version: 2.6
+  platforms:
+  - name: Debian
+    versions:
+     - wheezy
+     - jessie
+     - stretch
+
+  # Below are all categories currently available. Just as with
+  # the platforms above, uncomment those that apply to your role.
+  #
+  categories:
+  #- cloud
+  #- cloud:ec2
+  #- cloud:gce
+  #- cloud:rax
+  #- database
+  #- database:nosql
+  #- database:sql
+  #- development
+  #- monitoring
+  #- networking
+  #- packaging
+  - system
+  #- web
+dependencies: []
+


### PR DESCRIPTION
### Description
Add a meta file to prevent ansible-galaxy from complaining at install-time.

We'll have to discuss the license, I guess, especially since this role is based on someone else's work without an explicit license.

### Checklist
- [ ] Molecule tests are passing
- [x] Extended the README / documentation, if necessary
- [ ] Test for the feature added

